### PR TITLE
feat: add and document features to specify executable locations

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -20,6 +20,9 @@ structure Context where
   leanPrefix : System.FilePath
   gitLocation : System.FilePath
   enableNanoda : Bool
+  whichLandrun : String
+  whichLean4Export : String
+  whichNanoda : String
 
 abbrev M := ReaderT Context IO
 
@@ -86,18 +89,22 @@ def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
 
 def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
   let args := buildLandrunArgs spawnArgs
-  IO.Process.run {
-    cmd := "landrun",
+  let { stdout, stderr, exitCode } ← IO.Process.output {
+    cmd := (← read).whichLandrun,
     args,
-    stdout := .piped,
     env := spawnArgs.envOverride
     cwd := (← getProjectDir)
   }
+  IO.eprint stderr
+  if exitCode != 0 then
+    throw <| .userError s!"Child exited with {exitCode}"
+  return stdout
+
 
 def runSandBoxed (spawnArgs : LandrunArgs) : M Unit := do
   let args := buildLandrunArgs spawnArgs
   let proc ← IO.Process.spawn {
-    cmd := "landrun",
+    cmd := (← read).whichLandrun,
     args,
     env := spawnArgs.envOverride
     cwd := (← getProjectDir)
@@ -135,7 +142,7 @@ def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
   runSandBoxedWithStdout {
-    cmd := "lean4export",
+    cmd := (← read).whichLean4Export
     args := args,
     envPass := #["PATH", "HOME", "LEAN_PATH", "LEAN_ABORT_ON_PANIC"]
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
@@ -158,7 +165,7 @@ def runNanoda (solutionExport : String) : M Unit := do
     config.flush
 
     let spawnArgs := {
-      cmd := "nanoda_bin",
+      cmd := (← read).whichNanoda
       args := #[configPath.toString],
       envPass := #[]
       readablePaths := #[configPath.toString]
@@ -168,7 +175,7 @@ def runNanoda (solutionExport : String) : M Unit := do
 
     let args := buildLandrunArgs spawnArgs
     let proc ← IO.Process.spawn {
-      cmd := "landrun",
+      cmd := (← read).whichLandrun,
       args,
       stdin := .piped
       env := spawnArgs.envOverride
@@ -276,6 +283,9 @@ def M.run (x : M α) (cfg : Config) : IO α := do
   let cwd ← IO.Process.getCurrentDir
   let leanPrefix ← queryLeanPrefix cwd
   let gitLocation ← queryGitLocation
+  let whichLean4Export := (← IO.getEnv "COMPARATOR_LEAN4EXPORT").getD "lean4export"
+  let whichLandrun := (← IO.getEnv "COMPARATOR_LANDRUN").getD "landrun"
+  let whichNanoda := (← IO.getEnv "COMPARATOR_NANODA").getD "nanoda_bin"
   ReaderT.run x {
     projectDir := cwd
     challengeModule := cfg.challenge_module.toName,
@@ -285,7 +295,10 @@ def M.run (x : M α) (cfg : Config) : IO α := do
     legalAxioms := cfg.permitted_axioms.map String.toName,
     leanPrefix := leanPrefix,
     gitLocation := gitLocation,
-    enableNanoda := cfg.enable_nanoda
+    enableNanoda := cfg.enable_nanoda,
+    whichLean4Export,
+    whichLandrun,
+    whichNanoda
   }
 
 end Comparator

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # Comparator
 Comparator is a trustworthy judge for Lean proofs. It relies having an existing Lean installation as
 well as:
-1. [`landrun`](https://github.com/Zouuup/landrun), compiled from the `main` branch's source, present in the `PATH` or specified by the `COMPARATOR_LANDRUN` environment variable
-2. [`lean4export`](https://github.com/leanprover/lean4export/), at a version that is compatible with whatever Lean version your project is targeting, present in the `PATH`or specified by the `COMPARATOR_LEAN4EXPORT` environment variable
-3. (optional) [nanoda](https://github.com/ammkrn/nanoda_lib/) compiled with a recent version of Rust: `cargo build --release` will place `nanoda_bin` in the `target/release` folder of the checked-out directory. To enable nanoda verification, the folder for `nanoda_bin` must be present in the `PATH` or specified by the `COMPARATOR_NANODA` environment variable
+1. [`landrun`](https://github.com/Zouuup/landrun), compiled from the `main` branch's source, present in `PATH`
+2. [`lean4export`](https://github.com/leanprover/lean4export/), at a version that is compatible with whatever Lean version your project is targeting, present in `PATH`
+3. (optional) [nanoda](https://github.com/ammkrn/nanoda_lib/), compiled with a recent version of Rust.
+   This is only necessary if you want to check with the nanoda kernel in addition to the builtin one.
+   `cargo build --release` will place `nanoda_bin` in the `target/release` directory of the checked-out directory,
+   this directory must be present in `PATH`
+
+> [!NOTE]
+> Alternatively full paths to these binaries can be specified using the environment variables
+> `COMPARATOR_LANDRUN`, `COMPARATOR_LEAN4EXPORT`, and `COMPARATOR_NANODA` when invoking Comparator.
 
 Comparator is configured through a JSON file:
 ```
@@ -57,7 +64,8 @@ checking environment, `Solution.lean` will not be rebuilt.
 ## Checking with Additional Kernels
 Comparator currently supports checking with the [nanoda](https://github.com/ammkrn/nanoda_lib)
 kernel in addition to the builtin Lean one. To do this you need to set the `enable_nanoda` flag in
-the JSON configuration to `true`, and the `nanoda_bin` binary must be available to comparator through the `PATH` or `COMPARATOR_NANODA` environment variable.
+the JSON configuration to `true`, and the `nanoda_bin` binary must be available to comparator through
+`PATH` or the `COMPARATOR_NANODA` environment variable.
 
 ## Definition Holes
 Sometimes challenges want to leave open definitions for solutions to fill in. This can range from
@@ -134,7 +142,7 @@ name = "Solution"
 name = "Challenge"
 EOF
 
-COMPARATOR_LANDRUN=../../../scripts/fake-landrun.sh COMPARATOR_LEAN4EXPORT=../../../.lake/packages/lean4export/.lake/build/bin/lean4export lake env ../../../.lake/build/bin/comparator config.json
+COMPARATOR_LANDRUN=$(realpath ../../../scripts/fake-landrun.sh) COMPARATOR_LEAN4EXPORT=$(realpath ../../../.lake/packages/lean4export/.lake/build/bin/lean4export) lake env ../../../.lake/build/bin/comparator config.json
 ```
 
 The following commands, starting from the root directory of a fresh git checkout, will build and run the tests:
@@ -144,7 +152,7 @@ lake build lean4export comparator
 COMPARATOR_LANDRUN=$(realpath scripts/fake-landrun.sh) COMPARATOR_LEAN4EXPORT=$(realpath .lake/packages/lean4export/.lake/build/bin/lean4export) lean --run runtests.lean
 ```
 
-Replace the `landrun` and `lean4export` arguments as needed, or place the binaries on the `PATH`.
+Replace the `landrun` and `lean4export` arguments as needed, or place the binaries in `PATH`.
 
 ## Internals:
 We generally adopt a policy of not loading olean files as they just get mmaped into our address

--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ space and then dereferenced and are as such a potential point of attack for soph
 
 The comparator performs the following steps to ensure these properties:
 1. Build `Challenge` using `lake` in a `landrun` sandbox that has:
-  - read access to the entire file system and write access to `/dev`
-  - write access to the `.lake` directory of the project
+   - read access to the entire file system and write access to `/dev`
+   - write access to the `.lake` directory of the project
 2. Run `lean4export` on the produced `Challenge.olean` in a `landrun` sandbox that has:
-  - read access to the entire file system and write access to `/dev`
+   - read access to the entire file system and write access to `/dev`
 3. Repeat the same build sandboxed and export sandboxed steps with `Solution`
 4. Verify that all declarations used in the statement of all relevant theorems in `Challenge`
    are the same as in the `Solution` environment.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Comparator
 Comparator is a trustworthy judge for Lean proofs. It relies having an existing Lean installation as
-well as two additional binaries in `PATH`:
-1. [`landrun`](https://github.com/Zouuup/landrun) compiled from the `main` branch's source 
-2. [`lean4export`](https://github.com/leanprover/lean4export/) at a version that is compatible with
-   whatever Lean version your project is targeting.
+well as:
+1. [`landrun`](https://github.com/Zouuup/landrun), compiled from the `main` branch's source, present in the `PATH` or specified by the `COMPARATOR_LANDRUN` environment variable
+2. [`lean4export`](https://github.com/leanprover/lean4export/), at a version that is compatible with whatever Lean version your project is targeting, present in the `PATH`or specified by the `COMPARATOR_LEAN4EXPORT` environment variable
+3. (optional) [nanoda](https://github.com/ammkrn/nanoda_lib/) compiled with a recent version of Rust: `cargo build --release` will place `nanoda_bin` in the `target/release` folder of the checked-out directory. To enable nanoda verification, the folder for `nanoda_bin` must be present in the `PATH` or specified by the `COMPARATOR_NANODA` environment variable
 
-The comparator is configured through a JSON file:
+Comparator is configured through a JSON file:
 ```
 {
     "challenge_module": "Challenge",
@@ -57,12 +57,12 @@ checking environment, `Solution.lean` will not be rebuilt.
 ## Checking with Additional Kernels
 Comparator currently supports checking with the [nanoda](https://github.com/ammkrn/nanoda_lib)
 kernel in addition to the builtin Lean one. To do this you need to set the `enable_nanoda` flag in
-the JSON configuration to `true`. Note that this feature currently requires installing
-[nanoda](https://github.com/ammkrn/nanoda_lib/).
+the JSON configuration to `true`.
 
-To make nanoda available to comparator, you need install a recent Rust version and compile nanoda
-using `cargo build --release`. Then you need to add the `target/release` folder of the nanoda
-checkout to `PATH`.
+This feature currently requires installing [nanoda](https://github.com/ammkrn/nanoda_lib/).
+You need install a recent Rust version and compile nanoda using `cargo build --release`. 
+Then you need to add the `target/release` folder of the nanoda checkout to `PATH`, or specify the 
+location of the `nanoda_bin` library with `COMPARATOR_NANODA`.
 
 ## Definition Holes
 Sometimes challenges want to leave open definitions for solutions to fill in. This can range from
@@ -116,6 +116,40 @@ def large : Nat := 38
 
 theorem large_lt : 37 < large := by decide
 ```
+
+## Development
+
+The `scripts/fake-landrun.sh` can be used to replace Landrun in development if you are not on a Linux system that supports landrun.
+
+The following commands, starting from the root directory of a fresh git checkout, will build and run `comparator` on one of the test examples:
+
+```sh
+lake build lean4export comparator
+
+cd tests/projects/simple_mismatch
+
+cat > lakefile.toml <<EOF
+name = "comparatortest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"
+EOF
+
+COMPARATOR_LANDRUN=../../../scripts/fake-landrun.sh COMPARATOR_LEAN4EXPORT=../../../.lake/packages/lean4export/.lake/build/bin/lean4export lake env ../../../.lake/build/bin/comparator config.json
+```
+
+The following commands, starting from the root directory of a fresh git checkout, will build and run the tests:
+
+```sh
+lake build lean4export comparator
+COMPARATOR_LANDRUN=$(realpath scripts/fake-landrun.sh) COMPARATOR_LEAN4EXPORT=$(realpath .lake/packages/lean4export/.lake/build/bin/lean4export) lean --run runtests.lean
+```
+
+Replace the `landrun` and `lean4export` arguments as needed, or place the binaries on the `PATH`.
 
 ## Internals:
 We generally adopt a policy of not loading olean files as they just get mmaped into our address

--- a/README.md
+++ b/README.md
@@ -57,12 +57,7 @@ checking environment, `Solution.lean` will not be rebuilt.
 ## Checking with Additional Kernels
 Comparator currently supports checking with the [nanoda](https://github.com/ammkrn/nanoda_lib)
 kernel in addition to the builtin Lean one. To do this you need to set the `enable_nanoda` flag in
-the JSON configuration to `true`.
-
-This feature currently requires installing [nanoda](https://github.com/ammkrn/nanoda_lib/).
-You need install a recent Rust version and compile nanoda using `cargo build --release`. 
-Then you need to add the `target/release` folder of the nanoda checkout to `PATH`, or specify the 
-location of the `nanoda_bin` library with `COMPARATOR_NANODA`.
+the JSON configuration to `true`, and the `nanoda_bin` binary must be available to comparator through the `PATH` or `COMPARATOR_NANODA` environment variable.
 
 ## Definition Holes
 Sometimes challenges want to leave open definitions for solutions to fill in. This can range from

--- a/scripts/fake-landrun.sh
+++ b/scripts/fake-landrun.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# insecure and vibesick landrun shim that doesn't sandbox
+# don't use if you want any security obviously, intended for development on 
+# systems that don't support landrun (i.e. OSX)
+
+set -euo pipefail
+
+# Flags that take a value (consume the next arg).
+# Add more here if anything's missing.
+flags_with_value=(
+  --ro --rox --rw --rwx
+  --bind-tcp --connect-tcp
+  --log-level
+  --env
+)
+
+is_value_flag() {
+  local f="$1"
+  for vf in "${flags_with_value[@]}"; do
+    [[ "$f" == "$vf" ]] && return 0
+  done
+  return 1
+}
+
+# Handle subcommands / help / version like the real binary. Sorta.
+case "${1:-}" in
+  -h|--help)
+    cat <<'EOF'
+fake landrun shim/fake/stub - does nothing, runs your command unsandboxed
+
+Usage: landrun [flags] <command> [args...]
+
+Flags are accepted and ignored.
+EOF
+    exit 0
+    ;;
+  -V|--version)
+    echo "XXX NOT LANDRUN, FAKE SHIM XXX" >&2
+    exit 0
+    ;;
+esac
+
+# Parse and discard landrun's own flags until we hit `--` or a non-flag token.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --) shift; break ;; # End of flags
+    -*)
+      # Drop twice if it's a value-taking flag, always drop once
+      is_value_flag "$1" && shift
+      shift
+      ;;
+    *) break ;; # First non-flag token is the command to run
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "landrun shim: no command given" >&2
+  exit 2
+fi
+
+echo "WARNING: THIS IS NOT REAL LANDRUN! UNSAFELY RUNNING exec $*" >&2
+exec "$@"


### PR DESCRIPTION
In addition to a standard `lean` installation, comparator relies on a number of other binaries: `lean4export`, `landrun`, and `nanoda_bin` (optional). This primary change for this PR allows these binaries to be specifically configured instead of requiring them to be available on the PATH.

Secondary changes:
 - Adds several development-relevant examples for building and invoking comparator or tests to the README
 - Adds a script that fakes `landrun`, which can be used via setting `COMPARATOR_LANDRUN=$(realpath scripts/fake-landrun.sh)` as described in the modified README
 - Captures stderr from runSandBoxedWithStdout, sends it to stderr, primarily to make sure "You're using insecure fake landrun" messages get printed out correctly.