### PR TITLE
Insert '--' terminator before the sandboxed command in buildLandrunArgs

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -84,7 +84,7 @@ def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
   let args := spawnArgs.readablePaths.foldl (init := args) (fun acc path => acc ++ #["--ro", path.toString])
   let args := spawnArgs.writablePaths.foldl (init := args) (fun acc path => acc ++ #["--rwx", path.toString])
   let args := spawnArgs.executablePaths.foldl (init := args) (fun acc path => acc ++ #["--rox", path.toString])
-  args ++ #[spawnArgs.cmd] ++ spawnArgs.args
+  args ++ #["--", spawnArgs.cmd] ++ spawnArgs.args
 
 def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
   let args := buildLandrunArgs spawnArgs


### PR DESCRIPTION
landrun's CLI parser continues flag-scanning past positionals and consumes the first bare `--` in the command tail. `safeExport` passes exactly such a `--` to lean4export as the module/declaration separator (`#[module.toString, "--"]`), so lean4export receives the declaration names as *module* names and fails with:

```
uncaught exception: unknown module prefix 'wielandt_wintner'
No directory 'wielandt_wintner' or file 'wielandt_wintner.olean' in the search path entries: …
```

(lean4export v4.31.0 supports the `--` separator via `args.span (· != "--")` — the separator simply never reaches it.)

One-line fix: add the explicit flag terminator before the command in `buildLandrunArgs`, which also hardens the other sandboxed invocations (`lake build`, nanoda) against any future `--` in their argument lists.

Verified end-to-end on a real project (4-theorem config): with this patch the export, statement comparison, and axiom check all complete; without it the run dies at export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)