### PR TITLE
fix: comparator should not abort early when nanoda behaves oddly

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -171,27 +171,30 @@ def runNanoda (solutionExport : String) : M (Option String) := do
       writablePaths := #[]
       executablePaths := #[]
     }
-
     let args := buildLandrunArgs spawnArgs
-    let proc ← IO.Process.spawn {
-      cmd := (← read).whichLandrun,
-      args,
-      stdin := .piped
-      env := spawnArgs.envOverride
-      cwd := (← getProjectDir)
-    }
 
-    let (nanodaStdin, proc) ← proc.takeStdin
-    nanodaStdin.putStr solutionExport
-    nanodaStdin.flush
-    let ret ← proc.wait
-    if ret != 0 then
-      IO.println "Nanoda kernel rejected the solution"
-      return some s!"Child exited with {ret}"
-    else
-      IO.println "Nanoda kernel accepts the solution"
-      return none
+    try
+      let proc ← IO.Process.spawn {
+        cmd := (← read).whichLandrun,
+        args,
+        stdin := .piped
+        env := spawnArgs.envOverride
+        cwd := (← getProjectDir)
+      }
 
+      let (nanodaStdin, proc) ← proc.takeStdin
+      nanodaStdin.putStr solutionExport
+      nanodaStdin.flush
+      let ret ← proc.wait
+      if ret != 0 then
+        IO.println "Nanoda kernel rejected the solution"
+        return some s!"Child exited with {ret}"
+      else
+        IO.println "Nanoda kernel accepts the solution"
+        return none
+    catch e => do
+      IO.println "Error while interacting with nanoda"
+      return some s!"Error while interacting with nanoda: {e.toString}"
 
 def runKernel (solution : Export.ExportedEnv) : M (Option String) := do
   IO.println "Running Lean default kernel on solution."


### PR DESCRIPTION
This PR delays reporting comparator errors until the end of the process, even when `nanoda`
interactions lead to IO errors.

Notably it does not address the 127 exit code part of #67. Comparator will continue to interpret any
non-zero exit code as a rejection.

Fixes: #67
