### PR TITLE
fix: reject value substitution on non-sorry'd definitions

### DIFF
--- a/Comparator/Compare.lean
+++ b/Comparator/Compare.lean
@@ -34,6 +34,13 @@ def addWorklist (n : Lean.Name) : CompareM Unit := do
 def addRelevantConsts (info : Lean.ConstantInfo) : CompareM Unit := do
   runForUsedConsts info addWorklist
 
+/-- Check whether a ConstantInfo's value expression references `sorryAx`. -/
+def hasSorryAxValue : Lean.ConstantInfo → Bool
+  | .defnInfo dv => dv.value.getUsedConstants.any (· == ``sorryAx)
+  | .opaqueInfo ov => ov.value.getUsedConstants.any (· == ``sorryAx)
+  | .thmInfo tv => tv.value.getUsedConstants.any (· == ``sorryAx)
+  | _ => false
+
 partial def loop : CompareM Unit := do
   if (← get).worklist.isEmpty then
     return ()
@@ -52,8 +59,13 @@ partial def loop : CompareM Unit := do
       solutionConst.type.getUsedConstants.forM addWorklist
     else
       if challengeConst != solutionConst then
-        throw s!"Const does not match between challenge and target '{target}'"
-      addRelevantConsts solutionConst
+        if challengeConst.toConstantVal == solutionConst.toConstantVal
+            && hasSorryAxValue challengeConst then
+          solutionConst.type.getUsedConstants.forM addWorklist
+        else
+          throw s!"Const does not match between challenge and target '{target}'"
+      else
+        addRelevantConsts solutionConst
 
     modify fun s => { s with checked := s.checked.insert target }
     loop


### PR DESCRIPTION
Fixes: #85

`Compare.loop` accepts any dependency whose type matches between challenge
and solution, even when the value differs. This allows a submitter to
redefine a non-sorry'd definition to make a false challenge statement true.

### Changes

- Add `hasSorryAxValue`: checks whether a `ConstantInfo`'s value expression
  references `sorryAx` via `getUsedConstants`.
- Guard the type-only fallback in `Compare.loop`: when a constant's type
  matches but its value differs, accept only if the challenge-side value
  references `sorryAx`. Non-sorry definitions with mismatched values are
  rejected.

### Test cases

Reproducer at https://github.com/savarin/comparator-proof-bypass:
- `test-1-type-mismatch`: honest submission → PASS (unchanged)
- `test-2-value-cheat`: value substitution → **FAIL** (was PASS)
- `test-3-sorry-tolerance`: sorry'd definition → PASS (unchanged)